### PR TITLE
chore: release v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "afl"
-version = "0.15.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21e10b6947189c5ff61343b5354e9ad1c1722bd47b69cd0a6b49e5fa7f7ecf6"
-dependencies = [
- "home",
- "libc",
- "rustc_version",
- "xdg",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1373,105 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jdrouet-vrl"
+version = "0.17.0"
+dependencies = [
+ "aes",
+ "ansi_term",
+ "anyhow",
+ "arbitrary",
+ "base16",
+ "base62",
+ "base64 0.22.1",
+ "bytes",
+ "cbc",
+ "cfb-mode",
+ "cfg-if",
+ "chacha20poly1305",
+ "charset",
+ "chrono",
+ "chrono-tz",
+ "cidr-utils",
+ "clap",
+ "codespan-reporting",
+ "community-id",
+ "convert_case 0.6.0",
+ "criterion",
+ "crypto_secretbox",
+ "csv",
+ "ctr",
+ "data-encoding",
+ "digest",
+ "dns-lookup",
+ "domain",
+ "dyn-clone",
+ "exitcode",
+ "flate2",
+ "grok",
+ "hex",
+ "hmac",
+ "hostname",
+ "iana-time-zone",
+ "idna 0.5.0",
+ "indexmap 2.3.0",
+ "indoc",
+ "itertools 0.13.0",
+ "lalrpop",
+ "lalrpop-util",
+ "md-5",
+ "mlua",
+ "nom",
+ "ofb",
+ "once_cell",
+ "onig",
+ "ordered-float",
+ "paste",
+ "peeking_take_while",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "prettydiff",
+ "prettytable-rs",
+ "proptest",
+ "proptest-derive",
+ "prost",
+ "prost-reflect",
+ "psl",
+ "psl-types",
+ "publicsuffix",
+ "quickcheck",
+ "quoted_printable",
+ "rand",
+ "regex",
+ "roxmltree",
+ "rust_decimal",
+ "rustyline",
+ "seahash",
+ "serde",
+ "serde_json",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "snafu",
+ "snap",
+ "strip-ansi-escapes",
+ "syslog_loose",
+ "termcolor",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-test",
+ "uaparser",
+ "url",
+ "utf8-width",
+ "uuid",
+ "webbrowser",
+ "woothee",
+ "zstd",
+]
 
 [[package]]
 name = "jni"
@@ -3031,26 +3118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,133 +3459,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vrl"
-version = "0.17.0"
-dependencies = [
- "aes",
- "ansi_term",
- "anyhow",
- "arbitrary",
- "base16",
- "base62",
- "base64 0.22.1",
- "bytes",
- "cbc",
- "cfb-mode",
- "cfg-if",
- "chacha20poly1305",
- "charset",
- "chrono",
- "chrono-tz",
- "cidr-utils",
- "clap",
- "codespan-reporting",
- "community-id",
- "convert_case 0.6.0",
- "criterion",
- "crypto_secretbox",
- "csv",
- "ctr",
- "data-encoding",
- "digest",
- "dns-lookup",
- "domain",
- "dyn-clone",
- "exitcode",
- "flate2",
- "grok",
- "hex",
- "hmac",
- "hostname",
- "iana-time-zone",
- "idna 0.5.0",
- "indexmap 2.3.0",
- "indoc",
- "itertools 0.13.0",
- "lalrpop",
- "lalrpop-util",
- "md-5",
- "mlua",
- "nom",
- "ofb",
- "once_cell",
- "onig",
- "ordered-float",
- "paste",
- "peeking_take_while",
- "percent-encoding",
- "pest",
- "pest_derive",
- "prettydiff",
- "prettytable-rs",
- "proptest",
- "proptest-derive",
- "prost",
- "prost-reflect",
- "psl",
- "psl-types",
- "publicsuffix",
- "quickcheck",
- "quoted_printable",
- "rand",
- "regex",
- "roxmltree",
- "rust_decimal",
- "rustyline",
- "seahash",
- "serde",
- "serde_json",
- "sha-1",
- "sha2",
- "sha3",
- "snafu",
- "snap",
- "strip-ansi-escapes",
- "syslog_loose",
- "termcolor",
- "thiserror",
- "tokio",
- "toml",
- "tracing",
- "tracing-test",
- "uaparser",
- "url",
- "utf8-width",
- "uuid",
- "webbrowser",
- "woothee",
- "zstd",
-]
-
-[[package]]
-name = "vrl-cli"
-version = "0.1.0"
-dependencies = [
- "clap",
- "vrl",
-]
-
-[[package]]
-name = "vrl-fuzz"
-version = "0.1.0"
-dependencies = [
- "afl",
- "vrl",
-]
-
-[[package]]
-name = "vrl-tests"
-version = "0.1.0"
-dependencies = [
- "chrono-tz",
- "clap",
- "glob",
- "tikv-jemallocator",
- "tracing-subscriber",
- "vrl",
-]
 
 [[package]]
 name = "vte"
@@ -3934,15 +3874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "xdg"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688597db5a750e9cad4511cb94729a078e274308099a0382b5b8203bbc767fee"
-dependencies = [
- "home",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,48 +1,120 @@
 [package]
-name = "vrl"
+name = "jdrouet-vrl"
 version = "0.17.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 license = "MPL-2.0"
 description = "Vector Remap Language"
 homepage = "https://vrl.dev/"
-repository = "https://github.com/vectordotdev/vrl"
+repository = "https://github.com/jdrouet/vrl"
 readme = "README.md"
 keywords = ["vector", "datadog", "compiler"]
 categories = ["compilers"]
-rust-version = "1.78" # msrv
-
-[workspace]
-members = [
-  ".",
-  "lib/cli",
-  "lib/tests",
-  "lib/fuzz"
-]
-
+rust-version = "1.78"                                    # msrv
 
 [features]
-default = ["compiler", "value", "diagnostic", "path", "parser", "stdlib", "datadog", "core"]
+default = [
+  "compiler",
+  "value",
+  "diagnostic",
+  "path",
+  "parser",
+  "stdlib",
+  "datadog",
+  "core",
+]
 
 # Main features (on by default)
-compiler = ["diagnostic", "path", "parser", "value", "dep:paste", "dep:chrono", "dep:serde", "dep:regex", "dep:bytes", "dep:ordered-float", "dep:chrono-tz", "dep:snafu", "dep:thiserror", "dep:dyn-clone", "dep:indoc", "dep:thiserror", "dep:lalrpop-util"]
-value = ["path", "dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json"]
+compiler = [
+  "diagnostic",
+  "path",
+  "parser",
+  "value",
+  "dep:paste",
+  "dep:chrono",
+  "dep:serde",
+  "dep:regex",
+  "dep:bytes",
+  "dep:ordered-float",
+  "dep:chrono-tz",
+  "dep:snafu",
+  "dep:thiserror",
+  "dep:dyn-clone",
+  "dep:indoc",
+  "dep:thiserror",
+  "dep:lalrpop-util",
+]
+value = [
+  "path",
+  "dep:bytes",
+  "dep:regex",
+  "dep:ordered-float",
+  "dep:chrono",
+  "dep:serde_json",
+]
 diagnostic = ["dep:codespan-reporting", "dep:termcolor"]
 path = ["value", "dep:once_cell", "dep:serde", "dep:snafu", "dep:regex"]
-parser = ["path", "diagnostic", "value", "dep:thiserror", "dep:ordered-float", "dep:lalrpop-util"]
-parsing = ["value", "compiler", "dep:url", "dep:nom", "dep:regex", "dep:roxmltree", "dep:rust_decimal"]
+parser = [
+  "path",
+  "diagnostic",
+  "value",
+  "dep:thiserror",
+  "dep:ordered-float",
+  "dep:lalrpop-util",
+]
+parsing = [
+  "value",
+  "compiler",
+  "dep:url",
+  "dep:nom",
+  "dep:regex",
+  "dep:roxmltree",
+  "dep:rust_decimal",
+]
 core = ["value", "dep:snafu", "dep:nom"]
 string_path = []
 
 # Datadog related features (on by default)
 datadog = ["datadog_filter", "datadog_grok", "datadog_search"]
 datadog_filter = ["datadog_search", "dep:regex", "dep:dyn-clone"]
-datadog_grok = ["value", "parsing", "dep:nom", "dep:peeking_take_while", "dep:serde_json", "dep:onig", "dep:lalrpop-util", "dep:thiserror", "dep:chrono", "dep:chrono-tz", "dep:percent-encoding"]
-datadog_search = ["dep:pest", "dep:pest_derive", "dep:itertools", "dep:once_cell", "dep:regex"]
+datadog_grok = [
+  "value",
+  "parsing",
+  "dep:nom",
+  "dep:peeking_take_while",
+  "dep:serde_json",
+  "dep:onig",
+  "dep:lalrpop-util",
+  "dep:thiserror",
+  "dep:chrono",
+  "dep:chrono-tz",
+  "dep:percent-encoding",
+]
+datadog_search = [
+  "dep:pest",
+  "dep:pest_derive",
+  "dep:itertools",
+  "dep:once_cell",
+  "dep:regex",
+]
 
 # Features that aren't used as often (default off)
-cli = ["stdlib", "dep:serde_json", "dep:thiserror", "dep:clap", "dep:exitcode", "dep:webbrowser", "dep:rustyline", "dep:prettytable-rs"]
-test_framework = ["compiler", "dep:prettydiff", "dep:serde_json", "dep:ansi_term"]
+cli = [
+  "stdlib",
+  "dep:serde_json",
+  "dep:thiserror",
+  "dep:clap",
+  "dep:exitcode",
+  "dep:webbrowser",
+  "dep:rustyline",
+  "dep:prettytable-rs",
+]
+test_framework = [
+  "compiler",
+  "dep:prettydiff",
+  "dep:serde_json",
+  "dep:ansi_term",
+]
 arbitrary = ["dep:quickcheck", "dep:arbitrary"]
 lua = ["dep:mlua"]
 proptest = ["dep:proptest", "dep:proptest-derive"]
@@ -53,132 +125,159 @@ test = ["string_path"]
 
 # All stdlib functions
 stdlib = [
- "compiler",
- "core",
- "datadog",
- "parsing",
- "dep:aes",
- "dep:base16",
- "dep:base62",
- "dep:base64",
- "dep:cbc",
- "dep:cfb-mode",
- "dep:chacha20poly1305",
- "dep:charset",
- "dep:convert_case",
- "dep:cidr-utils",
- "dep:community-id",
- "dep:crypto_secretbox",
- "dep:csv",
- "dep:ctr",
- "dep:data-encoding",
- "dep:digest",
- "dep:domain",
- "dep:dns-lookup",
- "dep:flate2",
- "dep:grok",
- "dep:hex",
- "dep:hmac",
- "dep:hostname",
- "dep:iana-time-zone",
- "dep:idna",
- "dep:indexmap",
- "dep:md-5",
- "dep:nom",
- "dep:ofb",
- "dep:once_cell",
- "dep:percent-encoding",
- "dep:prost",
- "dep:prost-reflect",
- "dep:psl",
- "dep:psl-types",
- "dep:publicsuffix",
- "dep:quoted_printable",
- "dep:rand",
- "dep:roxmltree",
- "dep:rust_decimal",
- "dep:seahash",
- "dep:sha-1",
- "dep:sha-2",
- "dep:sha-3",
- "dep:snap",
- "dep:strip-ansi-escapes",
- "dep:syslog_loose",
- "dep:tokio",
- "dep:uaparser",
- "dep:url",
- "dep:utf8-width",
- "dep:uuid",
- "dep:woothee",
- "dep:zstd",
- ]
+  "compiler",
+  "core",
+  "datadog",
+  "parsing",
+  "dep:aes",
+  "dep:base16",
+  "dep:base62",
+  "dep:base64",
+  "dep:cbc",
+  "dep:cfb-mode",
+  "dep:chacha20poly1305",
+  "dep:charset",
+  "dep:convert_case",
+  "dep:cidr-utils",
+  "dep:community-id",
+  "dep:crypto_secretbox",
+  "dep:csv",
+  "dep:ctr",
+  "dep:data-encoding",
+  "dep:digest",
+  "dep:domain",
+  "dep:dns-lookup",
+  "dep:flate2",
+  "dep:grok",
+  "dep:hex",
+  "dep:hmac",
+  "dep:hostname",
+  "dep:iana-time-zone",
+  "dep:idna",
+  "dep:indexmap",
+  "dep:md-5",
+  "dep:nom",
+  "dep:ofb",
+  "dep:once_cell",
+  "dep:percent-encoding",
+  "dep:prost",
+  "dep:prost-reflect",
+  "dep:psl",
+  "dep:psl-types",
+  "dep:publicsuffix",
+  "dep:quoted_printable",
+  "dep:rand",
+  "dep:roxmltree",
+  "dep:rust_decimal",
+  "dep:seahash",
+  "dep:sha-1",
+  "dep:sha-2",
+  "dep:sha-3",
+  "dep:snap",
+  "dep:strip-ansi-escapes",
+  "dep:syslog_loose",
+  "dep:tokio",
+  "dep:uaparser",
+  "dep:url",
+  "dep:utf8-width",
+  "dep:uuid",
+  "dep:woothee",
+  "dep:zstd",
+]
 
 [dependencies]
 cfg-if = "1"
 
 # Optional dependencies
-ansi_term = {version = "0.12", optional = true }
+ansi_term = { version = "0.12", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 base16 = { version = "0.2", optional = true }
 base62 = { version = "2.0.2", optional = true }
 base64 = { version = "0.22", optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 charset = { version = "0.1", optional = true }
-chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"], optional = true }
+chrono = { version = "0.4", default-features = false, features = [
+  "clock",
+  "serde",
+  "wasmbind",
+], optional = true }
 chrono-tz = { version = "0.9", default-features = false, optional = true }
 cidr-utils = { version = "0.6", optional = true }
 csv = { version = "1", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
-codespan-reporting = {version = "0.11", optional = true }
+codespan-reporting = { version = "0.11", optional = true }
 convert_case = { version = "0.6.0", optional = true }
 data-encoding = { version = "2", optional = true }
 digest = { version = "0.10", optional = true }
 dyn-clone = { version = "1", default-features = false, optional = true }
-exitcode = {version = "1", optional = true }
-flate2 = { version = "1", default-features = false, features = ["default"], optional = true }
+exitcode = { version = "1", optional = true }
+flate2 = { version = "1", default-features = false, features = [
+  "default",
+], optional = true }
 hex = { version = "0.4", optional = true }
 hmac = { version = "0.12", optional = true }
 iana-time-zone = { version = "0.1", optional = true }
 idna = { version = "0.5", optional = true }
-indexmap = { version = "~2.3.0", default-features = false, features = ["std"], optional = true}
-indoc = {version = "2", optional = true }
+indexmap = { version = "~2.3.0", default-features = false, features = [
+  "std",
+], optional = true }
+indoc = { version = "2", optional = true }
 itertools = { version = "0.13", default-features = false, optional = true }
 lalrpop-util = { version = "0.20", optional = true }
-mlua = { version = "0.9", default-features = false, features = ["lua54", "send", "vendored"], optional = true}
-nom = { version = "7", default-features = false, features = ["std"], optional = true }
-once_cell = { version = "1", default-features = false, features = ["std"], optional = true }
+mlua = { version = "0.9", default-features = false, features = [
+  "lua54",
+  "send",
+  "vendored",
+], optional = true }
+nom = { version = "7", default-features = false, features = [
+  "std",
+], optional = true }
+once_cell = { version = "1", default-features = false, features = [
+  "std",
+], optional = true }
 ordered-float = { version = "4", default-features = false, optional = true }
 md-5 = { version = "0.10", optional = true }
 paste = { version = "1", default-features = false, optional = true }
 peeking_take_while = { version = "1", default-features = false, optional = true }
 percent-encoding = { version = "2", optional = true }
-pest = { version = "2", default-features = false, optional = true, features = ["std"] }
-pest_derive = { version = "2", default-features = false, optional = true, features = ["std"] }
+pest = { version = "2", default-features = false, optional = true, features = [
+  "std",
+] }
+pest_derive = { version = "2", default-features = false, optional = true, features = [
+  "std",
+] }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0.4", optional = true }
-prettydiff = {version = "0.7", default-features = false, optional = true }
+prettydiff = { version = "0.7", default-features = false, optional = true }
 prettytable-rs = { version = "0.10", default-features = false, optional = true }
 quickcheck = { version = "1", optional = true }
-quoted_printable = {version = "0.5", optional = true }
+quoted_printable = { version = "0.5", optional = true }
 psl = { version = "2", optional = true }
 psl-types = { version = "2", optional = true }
 publicsuffix = { version = "2", optional = true }
 rand = { version = "0.8", optional = true }
-regex = { version = "1", default-features = false, optional = true, features = ["std", "perf", "unicode"] }
+regex = { version = "1", default-features = false, optional = true, features = [
+  "std",
+  "perf",
+  "unicode",
+] }
 roxmltree = { version = "0.20", optional = true }
 rustyline = { version = "14", default-features = false, optional = true }
 rust_decimal = { version = "1", optional = true }
 seahash = { version = "4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
+serde_json = { version = "1", default-features = false, optional = true, features = [
+  "std",
+  "raw_value",
+] }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }
 strip-ansi-escapes = { version = "0.2", optional = true }
 snap = { version = "1", optional = true }
 syslog_loose = { version = "0.21", optional = true }
-termcolor = {version = "1", optional = true }
-thiserror ={ version =  "1", optional = true }
+termcolor = { version = "1", optional = true }
+thiserror = { version = "1", optional = true }
 tracing = { version = "0.1", default-features = false }
 uaparser = { version = "0.6", default-features = false, optional = true }
 utf8-width = { version = "0.1", optional = true }
@@ -186,9 +285,11 @@ url = { version = "2", optional = true }
 snafu = { version = "0.8", optional = true }
 webbrowser = { version = "1.0", default-features = false, optional = true }
 woothee = { version = "0.13", optional = true }
-community-id = { version = "0.2", optional = true}
+community-id = { version = "0.2", optional = true }
 
-zstd = { version = "0.13", default-features = false, features = ["wasm"], optional = true }
+zstd = { version = "0.13", default-features = false, features = [
+  "wasm",
+], optional = true }
 
 # Cryptography
 aes = { version = "0.8", optional = true }
@@ -202,17 +303,30 @@ cfb-mode = { version = "0.8", optional = true }
 ofb = { version = "0.6", optional = true }
 
 # Protobuf support.
-prost = { version = "0.13", default-features = false, optional = true, features = ["std"]}
-prost-reflect = { version = "0.14", default-features = false, optional = true}
+prost = { version = "0.13", default-features = false, optional = true, features = [
+  "std",
+] }
+prost-reflect = { version = "0.14", default-features = false, optional = true }
 
 # Dependencies used for non-WASM
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dns-lookup = { version = "2", optional = true }
-domain = { version = "0.10.1", optional = true, features = ["resolv-sync", "serde"] }
+domain = { version = "0.10.1", optional = true, features = [
+  "resolv-sync",
+  "serde",
+] }
 hostname = { version = "0.4", optional = true }
 grok = { version = "2", optional = true }
 onig = { version = "6", default-features = false, optional = true }
-tokio = { version = "1.38", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.38", optional = true, features = [
+  "io-util",
+  "macros",
+  "net",
+  "time",
+  "sync",
+  "rt",
+  "rt-multi-thread",
+] }
 uuid = { version = "1", features = ["v4", "v7"], optional = true }
 
 # Dependencies used for WASM
@@ -227,27 +341,20 @@ serde_json = "1"
 indoc = "2"
 tracing-test = { version = "0.2", default-features = false }
 toml = { version = "0.8", default-features = false }
-mlua = { version = "0.9", default-features = false, features = ["lua54", "send", "vendored"]}
-quickcheck = { version = "1"}
-regex = { version = "1", default-features = false, features = ["std", "perf", "unicode"] }
+mlua = { version = "0.9", default-features = false, features = [
+  "lua54",
+  "send",
+  "vendored",
+] }
+quickcheck = { version = "1" }
+regex = { version = "1", default-features = false, features = [
+  "std",
+  "perf",
+  "unicode",
+] }
 paste = { version = "1", default-features = false }
 proptest = { version = "1" }
 proptest-derive = { version = "0.4" }
 
 [build-dependencies]
 lalrpop = { version = "0.20", default-features = false }
-
-[[bench]]
-name = "kind"
-harness = false
-required-features = ["default", "test"]
-
-[[bench]]
-name = "keyvalue"
-harness = false
-required-features = ["default", "test"]
-
-[[bench]]
-name = "stdlib"
-harness = false
-required-features = ["default", "test"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+changelog_update = false # disable changelog updates


### PR DESCRIPTION
## 🤖 New release
* `jdrouet-vrl`: 0.17.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).